### PR TITLE
Change location from etc to lib

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@
 	dh $@
 
 override_dh_install:
-	mkdir -p debian/tmp/opt/delphix/server/etc
+	mkdir -p debian/tmp/opt/delphix/server/lib
 	docker pull registry.delphix.com/python:2.7.18-slim
-	docker save -o debian/tmp/opt/delphix/server/etc/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
+	docker save -o debian/tmp/opt/delphix/server/lib/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
From original review where this change was added to delphix/linux-pkg directly, I am moving the location that the file is saved at to a slightly different directory. 

https://github.com/delphix/linux-pkg/pull/137