### PR TITLE
Change location so git-au does not delete generated file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@
 	dh $@
 
 override_dh_install:
-	mkdir -p debian/tmp/opt/delphix/server/lib
+	mkdir -p debian/tmp/var/lib/delphix-virtualization
 	docker pull registry.delphix.com/python:2.7.18-slim
-	docker save -o debian/tmp/opt/delphix/server/lib/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
+	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
Changing the path of the generated file so that it's saved not under /opt/sever which gets cleared whenever git appliance update is run.

Tested this by modifying git-utils:
```
diff --git a/bin/lib/linux_pkg_packages.py b/bin/lib/linux_pkg_packages.py
index d4b60fd9..201aac73 100644
--- a/bin/lib/linux_pkg_packages.py
+++ b/bin/lib/linux_pkg_packages.py
@@ -27,6 +27,7 @@ LINUX_PKG_PACKAGES = [
     ("linux-3rd-party-pkgs", "crypt-blowfish", "userland"),
     ("delphix-kernel", "delphix-kernel", "kernel"),
     ("delphix-platform", "delphix-platform", "userland"),
+    ("docker-python-image", "docker-python-image", "userland"),
     ("saml-app", "delphix-sso-app", "userland"),
     ("drgn", "drgn", "userland"),
     ("gdb-python", "gdb-python", "userland"),
```

And running git ab-pre-push on this repo:
```
lindsey.nguyen@lnguyen-mbpro:~/Documents/docker-python-image$ git ab-pre-push
Detected linux-pkg package: docker-python-image
Waiting for build to start...
Your build is at: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4923/
```