### PR TITLE
CP-6011 docker-python-image should also pull + save Py3.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,5 +22,5 @@ Standards-Version: 4.1.2
 
 Package: docker-python-image
 Architecture: all
-Description: Saves the docker python:2.7.18-slim image to disk
+Description: Saves the docker python images to disk
  The python base image will be located at /opt/delphix/server/etc

--- a/debian/rules
+++ b/debian/rules
@@ -22,4 +22,6 @@ override_dh_install:
 	mkdir -p debian/tmp/var/lib/delphix-virtualization
 	docker pull registry.delphix.com/python:2.7.18-slim
 	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
+	docker pull registry.delphix.com/python:3.8-slim
+	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-3-8-slim.tar registry.delphix.com/python:3.8-slim
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
# Context:
With the move to support Python 3.8 in the vSDK/plugins, we need the base Python 3.8 docker image available on the engine as well as the 2.7 image that we already pull.

ab-pre-push is [here](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6131/). Failed during the blackbox run (before tests) due to a dependency issue, so unrelated to this change.

I cloned from the image created by the above job and SSHed in to check that both python images have been saved.
```
delphix@ip-10-110-216-163:~$ ls /var/lib/delphix-virtualization/
docker-python-2-7-18-slim.tar  docker-python-3-8-slim.tar
```
