### PR TITLE
CP-6687 [Backport of CP-6011 to 6.0/stage] docker-python-image should…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,5 +22,5 @@ Standards-Version: 4.1.2
 
 Package: docker-python-image
 Architecture: all
-Description: Saves the docker python:2.7.18-slim image to disk
+Description: Saves the docker python images to disk
  The python base image will be located at /opt/delphix/server/etc

--- a/debian/rules
+++ b/debian/rules
@@ -22,4 +22,6 @@ override_dh_install:
 	mkdir -p debian/tmp/var/lib/delphix-virtualization
 	docker pull registry.delphix.com/python:2.7.18-slim
 	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
+	docker pull registry.delphix.com/python:3.8-slim
+	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-3-8-slim.tar registry.delphix.com/python:3.8-slim
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
Backporting this change along with the effort to get SDK 4.0.0 released with DLPX 6.0.12.0