### PR TITLE
CP-11624 Create Docker Image for Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Docker Python Image
+
+This repository contains the script to pull the python 2.7, 3.8 and 3.11 slim images as tar files into Delphix engines.
+The location to save the images is `debian/tmp/var/lib/delphix-virtualization` and in Delphix engine it is saved at
+`/var/lib/delphix-virtualization`.
+
+## Contributing
+
+To add a new image, update the [rules](/debian/rules) file with the Python Slim image and version. The image should be
+present at `registry.delphix.com`.
+
+## License
+
+This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details.

--- a/debian/control
+++ b/debian/control
@@ -23,4 +23,4 @@ Standards-Version: 4.1.2
 Package: docker-python-image
 Architecture: all
 Description: Saves the docker python images to disk
- The python base image will be located at /opt/delphix/server/etc
+ The python base images will be located at /var/lib/delphix-virtualization

--- a/debian/rules
+++ b/debian/rules
@@ -24,4 +24,6 @@ override_dh_install:
 	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
 	docker pull registry.delphix.com/python:3.8-slim
 	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-3-8-slim.tar registry.delphix.com/python:3.8-slim
+	docker pull registry.delphix.com/python:3.11-slim
+	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-3-11-slim.tar registry.delphix.com/python:3.11-slim
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
### Problem
As Python 3.8 is coming to End of life by October 2024, we are working on extending the support to Python 3.11 for Virtualization SDK plugins.

### Solution
Add support for Python 3.11 version by adding the python:3.11-slim docker image tar to Delphix Engine.

The file size is around 129MB for Python 3.11 version.

```
root@ip-10-110-217-139:/var/lib/delphix-virtualization# ls -l --block-size=M
total 237M
-rw-r--r-- 1 root root 146M Jun 29  2023 docker-python-2-7-18-slim.tar
-rw------- 1 root root 129M Sep  3 09:43 docker-python-3-11-slim.tar
-rw-r--r-- 1 root root 147M Jun 29  2023 docker-python-3-8-slim.tar
root@ip-10-110-217-139:/var/lib/delphix-virtualization# 
```

### Testing Done
Tested the commands on Delphix engine directly and it saves the tar file on provided location.

<img width="603" alt="Screenshot 2024-09-03 at 3 15 01 PM" src="https://github.com/user-attachments/assets/e7963d01-658f-4ec9-8b1a-d62f8374627b">
