### PR TITLE
CP-13604 Remove Python 2.7/3.8 Docker image packaging from docker-python-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Python Image
 
-This repository contains the script to pull the python 2.7, 3.8 and 3.11 slim images as tar files into Delphix engines.
+This repository contains the script to pull the python 3.11 slim image as a tar file into Delphix engines.
 The location to save the images is `debian/tmp/var/lib/delphix-virtualization` and in Delphix engine it is saved at
 `/var/lib/delphix-virtualization`.
 

--- a/debian/rules
+++ b/debian/rules
@@ -20,10 +20,6 @@
 
 override_dh_install:
 	mkdir -p debian/tmp/var/lib/delphix-virtualization
-	docker pull registry.delphix.com/python:2.7.18-slim
-	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-2-7-18-slim.tar registry.delphix.com/python:2.7.18-slim
-	docker pull registry.delphix.com/python:3.8-slim
-	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-3-8-slim.tar registry.delphix.com/python:3.8-slim
 	docker pull registry.delphix.com/python:3.11-slim
 	docker save -o debian/tmp/var/lib/delphix-virtualization/docker-python-3-11-slim.tar registry.delphix.com/python:3.11-slim
 	dh_install --autodest "debian/tmp/*"


### PR DESCRIPTION
### Problem

`docker-python-image`'s `debian/rules` pulls, saves, and packages `python:2.7.18-slim` and `python:3.8-slim` Docker images alongside `python:3.11-slim`, shipping two unpatched EOL Python runtimes in every Delphix Engine build. Part of epic CP-13594 (Remove Python 2.7/3.8 Support for Delphix Engine); this is the lowest-risk first step, unblocking the engine-side removal work.

### Solution

Removed the `python:2.7.18-slim` and `python:3.8-slim` `docker pull`/`docker save` line pairs from `debian/rules`, leaving only the `python:3.11-slim` pull/save. Updated `README.md` so it no longer names 2.7/3.8 as images this build produces.

### Testing Done

- [ab-pre-push](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14843/)
- Checked the Delphix engine cloned from the above job and only Python 3.11 is saved now.
<img width="967" height="68" alt="Screenshot 2026-08-23 at 12 00 53 AM" src="https://github.com/user-attachments/assets/eecadf3a-02f1-4149-933d-0dd6810f801c" />
